### PR TITLE
Set Maven plugin versions and fix Sonar analysis and code coverage

### DIFF
--- a/core/src/test/java/com/coderanch/blackjack/CardTest.java
+++ b/core/src/test/java/com/coderanch/blackjack/CardTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assume.assumeThat;
  * Tests the {@link Card} class.
  */
 @RunWith(Theories.class)
-@SuppressWarnings("squid:S00100")
 public final class CardTest extends ConsistentComparableTest {
 
     /**

--- a/core/src/test/java/com/coderanch/blackjack/CardsTest.java
+++ b/core/src/test/java/com/coderanch/blackjack/CardsTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertThat;
  * Tests the {@link Cards} class.
  */
 @RunWith(Theories.class)
-@SuppressWarnings("squid:S00100")
 public final class CardsTest {
 
     /**

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -6,42 +6,22 @@
     xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 >
     <modelVersion>4.0.0</modelVersion>
-
+  
     <parent>
         <groupId>com.coderanch</groupId>
         <artifactId>blackjack-parent</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
+  
+    <artifactId>blackjack-coverage</artifactId>
 
-    <artifactId>blackjack-core</artifactId>
-
-    <name>Blackjack - Core library</name>
+    <name>Blackjack - Code coverage</name>
     
-    <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/../coverage/target/site/jacoco-aggregate/jacoco.xml
-        </sonar.coverage.jacoco.xmlReportPaths>
-    </properties>
-
     <dependencies>
         <dependency>
-            <groupId>com.coderanch</groupId>
-            <artifactId>test</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.coderanch</groupId>
-            <artifactId>util</artifactId>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <artifactId>blackjack-core</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
     
@@ -50,11 +30,12 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-
-                <executions>
+                
+                <executions>                    
                     <execution>
+                        <phase>verify</phase>
                         <goals>
-                            <goal>prepare-agent</goal>
+                            <goal>report-aggregate</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
+        <sonar.organization>coderanch-corral</sonar.organization>
+        <sonar.projectKey>com.coderanch:blackjack-parent</sonar.projectKey>
     </properties>
 
     <dependencyManagement>
@@ -69,4 +75,41 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+                
+                <plugin>
+                    <groupId>org.sonarsource.scanner.maven</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>3.8.0.2131</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns              = "http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi          = "http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 >
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,6 +30,7 @@
 
     <modules>
         <module>core</module>
+        <module>coverage</module>
         <module>test</module>
         <module>util</module>
     </modules>
@@ -76,7 +77,7 @@
         </dependencies>
     </dependencyManagement>
     
-    <build>
+    <build>        
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -87,6 +88,11 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
                 </plugin>
                 
                 <plugin>
@@ -102,6 +108,12 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>
+                </plugin>
+                
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.6</version>
                 </plugin>
                 
                 <plugin>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns              = "http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi          = "http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 >
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,10 +29,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
-        <sonar.coverage.exclusions>src/main/java/com/coderanch/test/**/*</sonar.coverage.exclusions>
+        <sonar.skip>true</sonar.skip>
     </properties>
 
     <dependencies>
@@ -48,4 +48,40 @@
             <version>1.3</version>
         </dependency>
     </dependencies>
+    
+    <build>        
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/test/src/main/java/com/coderanch/test/ComparableTest.java
+++ b/test/src/main/java/com/coderanch/test/ComparableTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assume.assumeThat;
 /**
  * Tests objects implementing the {@link Comparable} interface.
  */
-@SuppressWarnings({ "rawtypes", "unchecked", "squid:S00100" })
+@SuppressWarnings({ "rawtypes", "unchecked" })
 public class ComparableTest extends ObjectTest {
 
     /**

--- a/test/src/main/java/com/coderanch/test/ConsistentComparableTest.java
+++ b/test/src/main/java/com/coderanch/test/ConsistentComparableTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assume.assumeThat;
 /**
  * Tests whether objects implementing the {@link Comparable} interface are consistent-with-equals.
  */
-@SuppressWarnings({ "rawtypes", "unchecked", "squid:S00100" })
+@SuppressWarnings({ "rawtypes", "unchecked" })
 public class ConsistentComparableTest extends ComparableTest {
 
     /**

--- a/test/src/main/java/com/coderanch/test/ObjectTest.java
+++ b/test/src/main/java/com/coderanch/test/ObjectTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assume.assumeThat;
 /**
  * Tests the common methods of all objects.
  */
-@SuppressWarnings("squid:S00100")
 public class ObjectTest {
 
     /**

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns              = "http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi          = "http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 >
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,10 +29,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
-        <sonar.coverage.exclusions>src/main/java/com/coderanch/util/**/*</sonar.coverage.exclusions>
+        <sonar.skip>true</sonar.skip>
     </properties>
 
     <dependencies>
@@ -42,4 +42,40 @@
             <version>1.3</version>
         </dependency>
     </dependencies>
+    
+    <build>        
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
- Upgrade Java version to Java 11
- Use fixed versions for the clean, compiler, install, jar, resources and surefire maven plugins
- Add properties to fix Sonar analysis
- Add plugins to fix Sonar code coverage